### PR TITLE
refactor(pyo3): 更新pyo3依赖并重构代码以适应新版本- 将 pyo3 版本从 0.20.3 升级到0.23.5- 替换 …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,21 +13,23 @@ crate-type = ["cdylib"]
 atomic-bomb-engine = "0.41.1"
 #atomic-bomb-engine = { git = "https://github.com/we-lsp/atomic-bomb-engine.git", branch = "ExponentialMovingAverage"}
 tokio = "1.36.0"
-pyo3-asyncio = { version = "0.20.0", features = ["tokio-runtime", "async-std"] }
+pyo3-async-runtimes = { version = "0.23", features = ["attributes", "tokio-runtime"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = [] }
-serde-pyobject = "0.2.1"
+serde-pyobject = "0.6.2"
 async-std = "1.12.0"
 async-stream = "0.3.5"
 futures = "0.3.30"
 tokio-stream = "0.1.15"
 anyhow = "1.0.83"
+pythonize = "0.23"
 
 [build]
 rustflags = ["-C", "target-feature=+crt-static"]
 
+
 [dependencies.pyo3]
-version = "0.20.3"
+version = "0.23.5"
 features = ["extension-module", "auto-initialize"]
 
 [tool.maturin]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 #### [atomic-bomb-engine-front](https://github.com/GiantAxeWhy/atomic-bomb-engine-front)
 
 ## 使用条件：
-- python版本 >= 3.8
+- python版本 >= 3.8（已验证 3.8 - 3.13）
 - windows(x86), linux(x86), mac
 
 ## 使用方法：

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-maturin build --release --target x86_64-apple-darwin -i python3.8 -i python3.9 -i python3.10 -i python3.11 -i python3.12 &&
-maturin build --release -i python3.8 -i python3.9 -i python3.10 -i python3.11 -i python3.12 &&
+maturin build --release --target x86_64-apple-darwin -i python3.8 -i python3.9 -i python3.10 -i python3.11 -i python3.12 -i python3.13 &&
+maturin build --release -i python3.8 -i python3.9 -i python3.10 -i python3.11 -i python3.12 -i python3.13 &&
 twine upload --repository pypi --config-file ~/.pypirc ./target/wheels/* &&
 rm ./target/wheels/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,15 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/qyzhg/atomic-bomb-engine-py"
 keywords = ["rust", "python", "binding"]
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Rust",
     "Operating System :: OS Independent",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,11 @@
 use pyo3::prelude::*;
+use pyo3::types::PyModule;
 mod py_lib;
 mod utils;
 
 #[pymodule]
 #[pyo3(name = "atomic_bomb_engine")]
-fn atomic_bomb_engine(_py: Python, m: &PyModule) -> PyResult<()> {
+fn atomic_bomb_engine(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(
         py_lib::assert_option_func::assert_option,
         m

--- a/src/py_lib/assert_option_func.rs
+++ b/src/py_lib/assert_option_func.rs
@@ -1,5 +1,6 @@
 use pyo3::types::PyDict;
-use pyo3::{pyfunction, PyObject, PyResult, Python, ToPyObject};
+use pyo3::{pyfunction, PyObject, PyResult, Python};
+use pyo3::prelude::PyDictMethods;
 
 #[pyfunction]
 #[pyo3(signature=(
@@ -14,5 +15,5 @@ pub(crate) fn assert_option(
     let dict = PyDict::new(py);
     dict.set_item("jsonpath", jsonpath)?;
     dict.set_item("reference_object", reference_object)?;
-    Ok(dict.to_object(py))
+    Ok(dict.into_any().unbind())
 }

--- a/src/py_lib/batch_runner.rs
+++ b/src/py_lib/batch_runner.rs
@@ -2,8 +2,10 @@ use crate::utils;
 use atomic_bomb_engine::models::result::BatchResult;
 use futures::stream::BoxStream;
 use futures::StreamExt;
+use pyo3::prelude::PyDictMethods;
 use pyo3::types::{PyDict, PyList};
-use pyo3::{pyclass, pymethods, PyObject, PyRefMut, PyResult, Python, ToPyObject};
+use pyo3::{pyclass, pymethods, PyObject, PyRefMut, PyResult, Python};
+use pyo3::Py;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -43,9 +45,9 @@ impl BatchRunner {
         py: Python,
         test_duration_secs: u64,
         concurrent_requests: usize,
-        api_endpoints: &PyList,
-        step_option: Option<&PyDict>,
-        setup_options: Option<&PyList>,
+        api_endpoints: Py<PyList>,
+        step_option: Option<Py<PyDict>>,
+        setup_options: Option<Py<PyList>>,
         verbose: bool,
         should_prevent: bool,
         assert_channel_buffer_size: usize,
@@ -56,7 +58,7 @@ impl BatchRunner {
         let stream_clone = self.stream.clone();
         let endpoints = utils::parse_api_endpoints::new(py, api_endpoints)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
-        let step_opt = utils::parse_step_options::new(step_option)
+        let step_opt = utils::parse_step_options::new(py, step_option)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
         let setup_opts = utils::parse_setup_options::new(py, setup_options)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
@@ -81,7 +83,8 @@ impl BatchRunner {
         };
 
         Python::with_gil(|py| {
-            pyo3_asyncio::tokio::future_into_py(py, fut).map(|py_any| py_any.to_object(py))
+            pyo3_async_runtimes::tokio::future_into_py(py, fut)
+                .map(|py_any| py_any.unbind())
         })
     }
 
@@ -144,24 +147,21 @@ impl BatchRunner {
                                 "throughput_per_second_kb",
                                 test_result.throughput_per_second_kb,
                             )?;
-                            let http_error_list =
-                                utils::create_http_err_dict::create_http_error_dict(
-                                    py,
-                                    &test_result.http_errors,
-                                )?;
+                            let http_error_list = utils::create_http_err_dict::create_http_error_dict(
+                                py,
+                                &test_result.http_errors,
+                            )?;
                             dict.set_item("http_errors", http_error_list)?;
-                            let assert_error_list =
-                                utils::create_assert_err_dict::create_assert_error_dict(
-                                    py,
-                                    &test_result.assert_errors,
-                                )?;
+                            let assert_error_list = utils::create_assert_err_dict::create_assert_error_dict(
+                                py,
+                                &test_result.assert_errors,
+                            )?;
                             dict.set_item("assert_errors", assert_error_list)?;
                             dict.set_item("timestamp", test_result.timestamp)?;
-                            let api_results =
-                                utils::create_api_results_dict::create_api_results_dict(
-                                    py,
-                                    test_result.api_results,
-                                )?;
+                            let api_results = utils::create_api_results_dict::create_api_results_dict(
+                                py,
+                                test_result.api_results,
+                            )?;
                             dict.set_item("api_results", api_results)?;
                             dict.set_item(
                                 "total_concurrent_number",
@@ -169,7 +169,7 @@ impl BatchRunner {
                             )?;
                             dict.set_item("errors_per_second", test_result.errors_per_second)?;
                         };
-                        Ok(Some(dict.to_object(py)))
+                        Ok(Some(dict.into_any().unbind()))
                     }
                     Some(Err(e)) => Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
                     None => {
@@ -186,7 +186,7 @@ impl BatchRunner {
                 eprintln!("stream未初始化，请等待");
                 let dict = PyDict::new(py);
                 dict.set_item("should_wait", true)?;
-                Ok(Some(dict.to_object(py)))
+                Ok(Some(dict.into_any().unbind()))
             }
         }
     }

--- a/src/py_lib/endpoint_func.rs
+++ b/src/py_lib/endpoint_func.rs
@@ -1,5 +1,6 @@
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::PyDict;
 use pyo3::{pyfunction, PyObject, PyResult, Python};
+use pyo3::prelude::PyDictMethods;
 
 #[pyfunction]
 #[pyo3(signature=(
@@ -24,12 +25,12 @@ pub(crate) fn endpoint(
     weight: u32,
     json: Option<PyObject>,
     form_data: Option<PyObject>,
-    multipart_options: Option<&PyList>,
+    multipart_options: Option<PyObject>,
     headers: Option<PyObject>,
     cookies: Option<String>,
-    assert_options: Option<&PyList>,
+    assert_options: Option<PyObject>,
     think_time_option: Option<PyObject>,
-    setup_options: Option<&PyList>,
+    setup_options: Option<PyObject>,
 ) -> PyResult<PyObject> {
     let dict = PyDict::new(py);
     dict.set_item("name", name)?;

--- a/src/py_lib/jsonpath_extract_func.rs
+++ b/src/py_lib/jsonpath_extract_func.rs
@@ -1,5 +1,6 @@
 use pyo3::types::PyDict;
-use pyo3::{pyfunction, PyObject, PyResult, Python, ToPyObject};
+use pyo3::{pyfunction, PyObject, PyResult, Python};
+use pyo3::prelude::PyDictMethods;
 
 #[pyfunction]
 #[pyo3(signature=(
@@ -14,5 +15,5 @@ pub(crate) fn jsonpath_extract_option(
     let dict = PyDict::new(py);
     dict.set_item("key", key)?;
     dict.set_item("jsonpath", jsonpath)?;
-    Ok(dict.to_object(py))
+    Ok(dict.into_any().unbind())
 }

--- a/src/py_lib/multipart_option_func.rs
+++ b/src/py_lib/multipart_option_func.rs
@@ -1,5 +1,6 @@
 use pyo3::types::PyDict;
 use pyo3::{pyfunction, PyObject, PyResult, Python};
+use pyo3::prelude::PyDictMethods;
 
 #[pyfunction]
 #[pyo3(signature=(

--- a/src/py_lib/setup_option_func.rs
+++ b/src/py_lib/setup_option_func.rs
@@ -1,5 +1,6 @@
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::PyDict;
 use pyo3::{pyfunction, PyObject, PyResult, Python};
+use pyo3::prelude::PyDictMethods;
 
 #[pyfunction]
 #[pyo3(signature=(
@@ -20,10 +21,10 @@ pub(crate) fn setup_option(
     method: String,
     json: Option<PyObject>,
     form_data: Option<PyObject>,
-    multipart_options: Option<&PyList>,
+    multipart_options: Option<PyObject>,
     headers: Option<PyObject>,
     cookies: Option<String>,
-    jsonpath_extract: Option<&PyList>,
+    jsonpath_extract: Option<PyObject>,
 ) -> PyResult<PyObject> {
     let dict = PyDict::new(py);
     dict.set_item("name", name)?;

--- a/src/py_lib/step_option_func.rs
+++ b/src/py_lib/step_option_func.rs
@@ -1,5 +1,6 @@
 use pyo3::types::PyDict;
-use pyo3::{pyfunction, PyObject, PyResult, Python, ToPyObject};
+use pyo3::{pyfunction, PyObject, PyResult, Python};
+use pyo3::prelude::PyDictMethods;
 
 #[pyfunction]
 #[pyo3(signature=(
@@ -14,5 +15,5 @@ pub(crate) fn step_option(
     let dict = PyDict::new(py);
     dict.set_item("increase_step", increase_step)?;
     dict.set_item("increase_interval", increase_interval)?;
-    Ok(dict.to_object(py))
+    Ok(dict.into_any().unbind())
 }

--- a/src/py_lib/think_time_option_func.rs
+++ b/src/py_lib/think_time_option_func.rs
@@ -1,5 +1,6 @@
 use pyo3::types::PyDict;
-use pyo3::{pyfunction, PyObject, PyResult, Python, ToPyObject};
+use pyo3::{pyfunction, PyObject, PyResult, Python};
+use pyo3::prelude::PyDictMethods;
 
 #[pyfunction]
 #[pyo3(signature=(
@@ -14,5 +15,5 @@ pub(crate) fn think_time_option(
     let dict = PyDict::new(py);
     dict.set_item("min_millis", min_millis)?;
     dict.set_item("max_millis", max_millis)?;
-    Ok(dict.to_object(py))
+    Ok(dict.into_any().unbind())
 }

--- a/src/utils/create_api_results_dict.rs
+++ b/src/utils/create_api_results_dict.rs
@@ -1,12 +1,14 @@
 use atomic_bomb_engine::models::result::ApiResult;
+use pyo3::prelude::PyDictMethods;
 use pyo3::types::{PyDict, PyList};
-use pyo3::{PyResult, Python};
-pub fn create_api_results_dict(py: Python, api_results: Vec<ApiResult>) -> PyResult<&PyList> {
+use pyo3::{Py, PyResult, Python};
+
+pub fn create_api_results_dict(py: Python<'_>, api_results: Vec<ApiResult>) -> PyResult<Py<PyList>> {
     if api_results.is_empty() {
-        return Ok(PyList::empty(py));
+        return Ok(PyList::empty(py).unbind());
     }
 
-    let mut results = Vec::new();
+    let mut results: Vec<Py<PyDict>> = Vec::with_capacity(api_results.len());
 
     for result in api_results {
         let res_dict = PyDict::new(py);
@@ -29,7 +31,9 @@ pub fn create_api_results_dict(py: Python, api_results: Vec<ApiResult>) -> PyRes
         res_dict.set_item("total_data_kb", result.total_data_kb)?;
         res_dict.set_item("throughput_per_second_kb", result.throughput_per_second_kb)?;
         res_dict.set_item("concurrent_number", result.concurrent_number)?;
-        results.push(res_dict)
+
+        results.push(res_dict.unbind());
     }
-    Ok(PyList::new(py, results))
+
+    Ok(PyList::new(py, results)?.unbind())
 }

--- a/src/utils/create_assert_err_dict.rs
+++ b/src/utils/create_assert_err_dict.rs
@@ -1,29 +1,29 @@
-use atomic_bomb_engine::models::assert_error_stats::AssertErrKey;
-use pyo3::types::{PyDict, PyList};
-use pyo3::{PyResult, Python};
 use std::collections::HashMap;
 
-pub fn create_assert_error_dict<'py>(
-    py: Python<'py>,
+use atomic_bomb_engine::models::assert_error_stats::AssertErrKey;
+use pyo3::prelude::PyDictMethods;
+use pyo3::types::{PyDict, PyList};
+use pyo3::{Py, PyResult, Python};
+
+pub fn create_assert_error_dict(
+    py: Python<'_>,
     assert_errors: &HashMap<AssertErrKey, u32>,
-) -> PyResult<&'py PyList> {
+) -> PyResult<Py<PyList>> {
     if assert_errors.is_empty() {
-        return Ok(PyList::empty(py));
+        return Ok(PyList::empty(py).unbind());
     }
 
-    let mut result_errors = Vec::new();
+    let mut result_errors: Vec<Py<PyDict>> = Vec::with_capacity(assert_errors.len());
     for (assert_error_key, count) in assert_errors {
         let assert_error_dict = PyDict::new(py);
-        let assert_err_key_clone = assert_error_key.clone();
-
-        assert_error_dict.set_item("name", assert_err_key_clone.name)?;
-        assert_error_dict.set_item("message", assert_err_key_clone.msg)?;
-        assert_error_dict.set_item("url", assert_err_key_clone.url)?;
-        assert_error_dict.set_item("host", assert_err_key_clone.host)?;
-        assert_error_dict.set_item("path", assert_err_key_clone.path)?;
+        assert_error_dict.set_item("name", &assert_error_key.name)?;
+        assert_error_dict.set_item("message", &assert_error_key.msg)?;
+        assert_error_dict.set_item("url", &assert_error_key.url)?;
+        assert_error_dict.set_item("host", &assert_error_key.host)?;
+        assert_error_dict.set_item("path", &assert_error_key.path)?;
         assert_error_dict.set_item("count", count)?;
-
-        result_errors.push(assert_error_dict)
+        result_errors.push(assert_error_dict.unbind());
     }
-    Ok(PyList::new(py, result_errors))
+
+    Ok(PyList::new(py, result_errors)?.unbind())
 }

--- a/src/utils/create_http_err_dict.rs
+++ b/src/utils/create_http_err_dict.rs
@@ -1,28 +1,31 @@
-use atomic_bomb_engine::models::http_error_stats::HttpErrKey;
-use pyo3::types::{PyDict, PyList};
-use pyo3::{PyResult, Python};
 use std::collections::HashMap;
 
-pub fn create_http_error_dict<'py>(
-    py: Python<'py>,
+use atomic_bomb_engine::models::http_error_stats::HttpErrKey;
+use pyo3::prelude::PyDictMethods;
+use pyo3::types::{PyDict, PyList};
+use pyo3::{Py, PyResult, Python};
+
+pub fn create_http_error_dict(
+    py: Python<'_>,
     http_errors: &HashMap<HttpErrKey, u32>,
-) -> PyResult<&'py PyList> {
+) -> PyResult<Py<PyList>> {
     if http_errors.is_empty() {
-        return Ok(PyList::empty(py));
+        return Ok(PyList::empty(py).unbind());
     }
-    let mut http_errors_list = Vec::new();
+
+    let mut http_errors_list: Vec<Py<PyDict>> = Vec::with_capacity(http_errors.len());
     for (http_error_key, count) in http_errors {
-        let http_error_key_clone = http_error_key.clone();
         let http_error_dict = PyDict::new(py);
-        http_error_dict.set_item("name", http_error_key_clone.name)?;
-        http_error_dict.set_item("code", http_error_key_clone.code)?;
-        http_error_dict.set_item("message", http_error_key_clone.msg)?;
-        http_error_dict.set_item("url", http_error_key_clone.url)?;
-        http_error_dict.set_item("host", http_error_key_clone.host)?;
-        http_error_dict.set_item("path", http_error_key_clone.path)?;
-        http_error_dict.set_item("source", http_error_key_clone.source)?;
+        http_error_dict.set_item("name", &http_error_key.name)?;
+        http_error_dict.set_item("code", http_error_key.code)?;
+        http_error_dict.set_item("message", &http_error_key.msg)?;
+        http_error_dict.set_item("url", &http_error_key.url)?;
+        http_error_dict.set_item("host", &http_error_key.host)?;
+        http_error_dict.set_item("path", &http_error_key.path)?;
+        http_error_dict.set_item("source", &http_error_key.source)?;
         http_error_dict.set_item("count", count)?;
-        http_errors_list.push(http_error_dict)
+        http_errors_list.push(http_error_dict.unbind());
     }
-    Ok(PyList::new(py, http_errors_list))
+
+    Ok(PyList::new(py, http_errors_list)?.unbind())
 }

--- a/src/utils/parse_api_endpoints.rs
+++ b/src/utils/parse_api_endpoints.rs
@@ -1,236 +1,99 @@
 use crate::utils;
+use std::collections::HashMap;
+
 use atomic_bomb_engine::models;
 use atomic_bomb_engine::models::api_endpoint::ThinkTime;
 use atomic_bomb_engine::models::assert_option::AssertOption;
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyAnyMethods, PyDict, PyList, PyListMethods};
+use pythonize::depythonize;
 use serde_json::Value;
-use serde_pyobject::from_pyobject;
-use std::collections::HashMap;
 
-pub fn new(py: Python, api_endpoints: &PyList) -> PyResult<Vec<models::api_endpoint::ApiEndpoint>> {
+pub fn new(py: Python<'_>, api_endpoints: Py<PyList>) -> PyResult<Vec<models::api_endpoint::ApiEndpoint>> {
     let mut endpoints: Vec<models::api_endpoint::ApiEndpoint> = Vec::new();
-    for item in api_endpoints.iter() {
-        if let Ok(dict) = item.downcast::<PyDict>() {
-            let name: String = match dict.get_item("name") {
-                Ok(name) => match name {
-                    None => {
-                        return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                            "name不能为空".to_string(),
-                        ))
-                    }
-                    Some(name) => name.to_string(),
-                },
-                Err(e) => {
-                    return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "Error: {:?}",
-                        e
-                    )))
-                }
-            };
+    let bound_list = api_endpoints.bind(py);
+    for item in bound_list.iter() {
+        let dict = item.downcast::<PyDict>()?;
 
-            let url: String = match dict.get_item("url") {
-                Ok(url) => match url {
-                    None => {
-                        return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                            "url不能为空".to_string(),
-                        ))
-                    }
-                    Some(url) => url.to_string(),
-                },
-                Err(e) => {
-                    return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "Error: {:?}",
-                        e
-                    )))
-                }
-            };
+        let name: String = dict
+            .get_item("name")?
+            .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("name不能为空".to_string()))?
+            .extract()?;
 
-            let method: String = match dict.get_item("method") {
-                Ok(method) => match method {
-                    None => {
-                        return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                            "method不能为空".to_string(),
-                        ))
-                    }
-                    Some(method) => method.to_string(),
-                },
-                Err(e) => {
-                    return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "Error: {:?}",
-                        e
-                    )))
-                }
-            };
+        let url: String = dict
+            .get_item("url")?
+            .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("url不能为空".to_string()))?
+            .extract()?;
 
-            let weight: u32 = match dict.get_item("weight") {
-                Ok(weight) => match weight {
-                    None => {
-                        return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                            "weight不能为空".to_string(),
-                        ))
-                    }
-                    Some(weight) => weight.to_string().parse()?,
-                },
-                Err(e) => {
-                    return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "Error: {:?}",
-                        e
-                    )))
-                }
-            };
+        let method: String = dict
+            .get_item("method")?
+            .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("method不能为空".to_string()))?
+            .extract()?;
 
-            let json_obj: PyObject = dict.get_item("json").unwrap().to_object(py);
-            let json: Option<Value> = match from_pyobject(json_obj.as_ref(py)) {
-                Ok(val) => val,
-                Err(e) => {
-                    return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "Error: {:?}",
-                        e
-                    )))
-                }
-            };
+        let weight: u32 = dict
+            .get_item("weight")?
+            .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("weight不能为空".to_string()))?
+            .extract()?;
 
-            let form_data_obj: PyObject = dict.get_item("form_data").unwrap().to_object(py);
-            let form_data: Option<HashMap<String, String>> =
-                match from_pyobject(form_data_obj.as_ref(py)) {
-                    Ok(val) => val,
-                    Err(e) => {
-                        return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                            "Error: {:?}",
-                            e
-                        )))
-                    }
-                };
+        let json: Option<Value> = dict
+            .get_item("json")?
+            .map(|value| depythonize(&value).map_err(|e| PyErr::new::<PyRuntimeError, _>(format!("Error: {:?}", e))))
+            .transpose()?;
 
-            let headers_obj: PyObject = dict.get_item("headers").unwrap().to_object(py);
-            let headers: Option<HashMap<String, String>> =
-                match from_pyobject(headers_obj.as_ref(py)) {
-                    Ok(val) => val,
-                    Err(e) => {
-                        return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                            "Error: {:?}",
-                            e
-                        )))
-                    }
-                };
+        let form_data: Option<HashMap<String, String>> = dict
+            .get_item("form_data")?
+            .map(|value| depythonize(&value).map_err(|e| PyErr::new::<PyRuntimeError, _>(format!("Error: {:?}", e))))
+            .transpose()?;
 
-            let cookies_obj: PyObject = dict.get_item("cookies").unwrap().to_object(py);
-            let cookies: Option<String> = match from_pyobject(cookies_obj.as_ref(py)) {
-                Ok(val) => val,
-                Err(e) => {
-                    return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "Error: {:?}",
-                        e
-                    )))
-                }
-            };
+        let headers: Option<HashMap<String, String>> = dict
+            .get_item("headers")?
+            .map(|value| depythonize(&value).map_err(|e| PyErr::new::<PyRuntimeError, _>(format!("Error: {:?}", e))))
+            .transpose()?;
 
-            let assert_options: Option<Vec<AssertOption>> = match dict.get_item("assert_options") {
-                Ok(op_py_any) => match op_py_any {
-                    None => None,
-                    Some(py_any) => {
-                        let pyobj = py_any.to_object(py);
-                        match from_pyobject(pyobj.as_ref(py)) {
-                            Ok(val) => val,
-                            Err(e) => {
-                                return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                                    format!("Error: {:?}", e),
-                                ))
-                            }
-                        }
-                    }
-                },
-                Err(e) => {
-                    return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "Error: {:?}",
-                        e
-                    )))
-                }
-            };
+        let cookies: Option<String> = dict
+            .get_item("cookies")?
+            .map(|value| depythonize(&value).map_err(|e| PyErr::new::<PyRuntimeError, _>(format!("Error: {:?}", e))))
+            .transpose()?;
 
-            let think_time_option: Option<ThinkTime> = match dict.get_item("think_time_option") {
-                Ok(op_py_any) => match op_py_any {
-                    None => None,
-                    Some(py_any) => {
-                        let pyobj = py_any.to_object(py);
-                        match from_pyobject(pyobj.as_ref(py)) {
-                            Ok(val) => val,
-                            Err(e) => {
-                                return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                                    format!("Error: {:?}", e),
-                                ))
-                            }
-                        }
-                    }
-                },
-                Err(e) => {
-                    return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "Error: {:?}",
-                        e
-                    )))
-                }
-            };
-            let setup_options_pylist: Option<&PyList> = match dict.get_item("setup_options") {
-                Ok(opts) => match opts {
-                    None => None,
-                    Some(py_any) => match py_any.extract::<&PyList>() {
-                        Ok(py_list) => Some(py_list),
-                        Err(e) => {
-                            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                                "Error: {:?}",
-                                e
-                            )))
-                        }
-                    },
-                },
-                Err(e) => {
-                    return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "Error: {:?}",
-                        e
-                    )))
-                }
-            };
-            let setup_options = utils::parse_setup_options::new(py, setup_options_pylist)?;
+        let assert_options: Option<Vec<AssertOption>> = dict
+            .get_item("assert_options")?
+            .map(|value| depythonize(&value).map_err(|e| PyErr::new::<PyRuntimeError, _>(format!("Error: {:?}", e))))
+            .transpose()?;
 
-            let multipart_options_pylist: Option<&PyList> =
-                match dict.get_item("multipart_options") {
-                    Ok(opts) => match opts {
-                        None => None,
-                        Some(py_any) => match py_any.extract::<&PyList>() {
-                            Ok(py_list) => Some(py_list),
-                            Err(e) => {
-                                return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                                    format!("Error: {:?}", e),
-                                ))
-                            }
-                        },
-                    },
-                    Err(e) => {
-                        return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                            "Error: {:?}",
-                            e
-                        )))
-                    }
-                };
-            let multipart_options =
-                utils::parse_multipart_options::new(py, multipart_options_pylist)?;
+        let think_time_option: Option<ThinkTime> = dict
+            .get_item("think_time_option")?
+            .map(|value| depythonize(&value).map_err(|e| PyErr::new::<PyRuntimeError, _>(format!("Error: {:?}", e))))
+            .transpose()?;
 
-            endpoints.push(models::api_endpoint::ApiEndpoint {
-                name,
-                url,
-                method,
-                weight,
-                json,
-                form_data,
-                multipart_options,
-                headers,
-                cookies,
-                assert_options,
-                think_time_option,
-                setup_options,
-            });
-        }
+        let setup_options = dict
+            .get_item("setup_options")?
+            .map(|value| value.extract::<Py<PyList>>())
+            .transpose()?;
+
+        let setup_options = utils::parse_setup_options::new(py, setup_options)?;
+
+        let multipart_options = dict
+            .get_item("multipart_options")?
+            .map(|value| value.extract::<Py<PyList>>())
+            .transpose()?;
+
+        let multipart_options = utils::parse_multipart_options::new(py, multipart_options)?;
+
+        endpoints.push(models::api_endpoint::ApiEndpoint {
+            name,
+            url,
+            method,
+            weight,
+            json,
+            form_data,
+            multipart_options,
+            headers,
+            cookies,
+            assert_options,
+            think_time_option,
+            setup_options,
+        });
     }
     Ok(endpoints)
 }

--- a/src/utils/parse_assert_options.rs
+++ b/src/utils/parse_assert_options.rs
@@ -1,52 +1,37 @@
 use atomic_bomb_engine::models;
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyAnyMethods, PyDict, PyList, PyListMethods};
+use pythonize::depythonize;
 use serde_json::Value;
-use serde_pyobject::from_pyobject;
 
 pub fn _new(
-    py: Python,
-    assert_options: Option<&PyList>,
+    py: Python<'_>,
+    assert_options: Option<Py<PyList>>,
 ) -> PyResult<Option<Vec<models::assert_option::AssertOption>>> {
     match assert_options {
         None => Ok(None),
         Some(ops_list) => {
-            let mut ops: Vec<models::assert_option::AssertOption> = Vec::new();
-            for item in ops_list.iter() {
-                if let Ok(dict) = item.downcast::<PyDict>() {
-                    let jsonpath: String = match dict.get_item("jsonpath") {
-                        Ok(json_path_option) => match json_path_option {
-                            None => {
-                                return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                                    "必须输入一个jsonpath".to_string(),
-                                ))
-                            }
-                            Some(jsonpath) => jsonpath.to_string(),
-                        },
-                        Err(e) => {
-                            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                                "Error: {:?}",
-                                e
-                            )))
-                        }
-                    };
+            let list = ops_list.bind(py);
+            let mut ops: Vec<models::assert_option::AssertOption> = Vec::with_capacity(list.len());
+            for item in list.iter() {
+                let dict = item.downcast::<PyDict>()?;
+                let jsonpath: String = dict
+                    .get_item("jsonpath")?
+                    .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("必须输入一个jsonpath".to_string()))?
+                    .extract()?;
 
-                    let reference_object: PyObject =
-                        dict.get_item("reference_object").unwrap().to_object(py);
-                    let reference_value: Value = match from_pyobject(reference_object.as_ref(py)) {
-                        Ok(val) => val,
-                        Err(e) => {
-                            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                                "Error: {:?}",
-                                e
-                            )))
-                        }
-                    };
-                    ops.push(models::assert_option::AssertOption {
-                        jsonpath,
-                        reference_object: reference_value,
-                    });
-                }
+                let reference_value = dict
+                    .get_item("reference_object")?
+                    .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("必须输入一个reference_object".to_string()))?;
+                let reference_object: Value = depythonize(&reference_value).map_err(|e| {
+                    PyErr::new::<PyRuntimeError, _>(format!("Error: {:?}", e))
+                })?;
+
+                ops.push(models::assert_option::AssertOption {
+                    jsonpath,
+                    reference_object,
+                });
             }
             Ok(Some(ops))
         }

--- a/src/utils/parse_multipart_options.rs
+++ b/src/utils/parse_multipart_options.rs
@@ -1,94 +1,51 @@
 use atomic_bomb_engine::models;
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyAnyMethods, PyDict, PyList, PyListMethods};
 
 pub fn new(
-    _py: Python,
-    py_multipart_options: Option<&PyList>,
+    py: Python<'_>,
+    py_multipart_options: Option<Py<PyList>>,
 ) -> PyResult<Option<Vec<models::multipart_option::MultipartOption>>> {
-    return match py_multipart_options {
+    match py_multipart_options {
         None => Ok(None),
-        Some(ops) => {
-            let mut multipart_options: Vec<models::multipart_option::MultipartOption> = Vec::new();
-            for item in ops.iter() {
-                if let Ok(dict) = item.downcast::<PyDict>() {
-                    let form_key: String = match dict.get_item("form_key") {
-                        Ok(form_key) => match form_key {
-                            None => {
-                                return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                                    "form_key".to_string(),
-                                ))
-                            }
-                            Some(form_key) => form_key.to_string(),
-                        },
-                        Err(e) => {
-                            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                                "Error: {:?}",
-                                e
-                            )))
-                        }
-                    };
+        Some(ops_list) => {
+            let list = ops_list.bind(py);
+            let mut multipart_options: Vec<models::multipart_option::MultipartOption> =
+                Vec::with_capacity(list.len());
 
-                    let path: String = match dict.get_item("path") {
-                        Ok(path) => match path {
-                            None => {
-                                return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                                    "path".to_string(),
-                                ))
-                            }
-                            Some(path) => path.to_string(),
-                        },
-                        Err(e) => {
-                            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                                "Error: {:?}",
-                                e
-                            )))
-                        }
-                    };
+            for item in list.iter() {
+                let dict = item.downcast::<PyDict>()?;
 
-                    let file_name: String = match dict.get_item("file_name") {
-                        Ok(file_name) => match file_name {
-                            None => {
-                                return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                                    "file_name".to_string(),
-                                ))
-                            }
-                            Some(file_name) => file_name.to_string(),
-                        },
-                        Err(e) => {
-                            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                                "Error: {:?}",
-                                e
-                            )))
-                        }
-                    };
+                let form_key: String = dict
+                    .get_item("form_key")?
+                    .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("form_key 不能为空".to_string()))?
+                    .extract()?;
 
-                    let mime: String = match dict.get_item("mime") {
-                        Ok(mime) => match mime {
-                            None => {
-                                return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                                    "mime".to_string(),
-                                ))
-                            }
-                            Some(mime) => mime.to_string(),
-                        },
-                        Err(e) => {
-                            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                                "Error: {:?}",
-                                e
-                            )))
-                        }
-                    };
+                let path: String = dict
+                    .get_item("path")?
+                    .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("path 不能为空".to_string()))?
+                    .extract()?;
 
-                    multipart_options.push(models::multipart_option::MultipartOption {
-                        form_key,
-                        path,
-                        file_name,
-                        mime,
-                    })
-                }
+                let file_name: String = dict
+                    .get_item("file_name")?
+                    .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("file_name 不能为空".to_string()))?
+                    .extract()?;
+
+                let mime: String = dict
+                    .get_item("mime")?
+                    .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("mime 不能为空".to_string()))?
+                    .extract()?;
+
+                multipart_options.push(models::multipart_option::MultipartOption {
+                    form_key,
+                    path,
+                    file_name,
+                    mime,
+                });
             }
-            Ok(Option::from(multipart_options))
+
+            Ok(Some(multipart_options))
         }
-    };
+    }
 }

--- a/src/utils/parse_setup_options.rs
+++ b/src/utils/parse_setup_options.rs
@@ -1,186 +1,97 @@
 use std::collections::HashMap;
 
 use atomic_bomb_engine::models;
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyAnyMethods, PyDict, PyList, PyListMethods};
+use pythonize::depythonize;
 use serde_json::Value;
-use serde_pyobject::from_pyobject;
 
 pub fn new(
-    py: Python,
-    py_setup_options: Option<&PyList>,
+    py: Python<'_>,
+    py_setup_options: Option<Py<PyList>>,
 ) -> PyResult<Option<Vec<models::setup::SetupApiEndpoint>>> {
-    return match py_setup_options {
+    match py_setup_options {
         None => Ok(None),
-        Some(ops) => {
-            let mut setup_options: Vec<models::setup::SetupApiEndpoint> = Vec::new();
-            for item in ops.iter() {
-                if let Ok(dict) = item.downcast::<PyDict>() {
-                    let name: String = match dict.get_item("name") {
-                        Ok(name) => match name {
-                            None => {
-                                return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                                    "name不能为空".to_string(),
-                                ))
-                            }
-                            Some(name) => name.to_string(),
-                        },
-                        Err(e) => {
-                            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                                "Error: {:?}",
-                                e
-                            )))
-                        }
-                    };
+        Some(options) => {
+            let list = options.bind(py);
+            let mut setup_options: Vec<models::setup::SetupApiEndpoint> =
+                Vec::with_capacity(list.len());
 
-                    let url: String = match dict.get_item("url") {
-                        Ok(url) => match url {
-                            None => {
-                                return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                                    "url不能为空".to_string(),
-                                ))
-                            }
-                            Some(url) => url.to_string(),
-                        },
-                        Err(e) => {
-                            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                                "Error: {:?}",
-                                e
-                            )))
-                        }
-                    };
+            for item in list.iter() {
+                let dict = item.downcast::<PyDict>()?;
 
-                    let method: String = match dict.get_item("method") {
-                        Ok(method) => match method {
-                            None => {
-                                return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                                    "method不能为空".to_string(),
-                                ))
-                            }
-                            Some(method) => method.to_string(),
-                        },
-                        Err(e) => {
-                            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                                "Error: {:?}",
-                                e
-                            )))
-                        }
-                    };
+                let name: String = dict
+                    .get_item("name")?
+                    .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("name不能为空".to_string()))?
+                    .extract()?;
 
-                    let json_obj: PyObject = dict.get_item("json").unwrap().to_object(py);
-                    let json: Option<Value> = match from_pyobject(json_obj.as_ref(py)) {
-                        Ok(val) => val,
-                        Err(e) => {
-                            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                                "Error: {:?}",
-                                e
-                            )))
-                        }
-                    };
+                let url: String = dict
+                    .get_item("url")?
+                    .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("url不能为空".to_string()))?
+                    .extract()?;
 
-                    let form_data_obj: PyObject = dict.get_item("form_data").unwrap().to_object(py);
-                    let form_data: Option<HashMap<String, String>> =
-                        match from_pyobject(form_data_obj.as_ref(py)) {
-                            Ok(val) => val,
-                            Err(e) => {
-                                return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                                    format!("Error: {:?}", e),
-                                ))
-                            }
-                        };
+                let method: String = dict
+                    .get_item("method")?
+                    .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("method不能为空".to_string()))?
+                    .extract()?;
 
-                    let headers_obj: PyObject = dict.get_item("headers").unwrap().to_object(py);
-                    let headers: Option<HashMap<String, String>> =
-                        match from_pyobject(headers_obj.as_ref(py)) {
-                            Ok(val) => val,
-                            Err(e) => {
-                                return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                                    format!("Error: {:?}", e),
-                                ))
-                            }
-                        };
+                let json: Option<Value> = dict
+                    .get_item("json")?
+                    .map(|value| depythonize(&value).map_err(|e| {
+                        PyErr::new::<PyRuntimeError, _>(format!("Error: {:?}", e))
+                    }))
+                    .transpose()?;
 
-                    let cookies_obj: PyObject = dict.get_item("cookies").unwrap().to_object(py);
-                    let cookies: Option<String> = match from_pyobject(cookies_obj.as_ref(py)) {
-                        Ok(val) => val,
-                        Err(e) => {
-                            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                                "Error: {:?}",
-                                e
-                            )))
-                        }
-                    };
+                let form_data: Option<HashMap<String, String>> = dict
+                    .get_item("form_data")?
+                    .map(|value| depythonize(&value).map_err(|e| {
+                        PyErr::new::<PyRuntimeError, _>(format!("Error: {:?}", e))
+                    }))
+                    .transpose()?;
 
-                    let jsonpath_extract: Option<Vec<models::setup::JsonpathExtract>> = match dict
-                        .get_item("jsonpath_extract")
-                    {
-                        Ok(op_py_any) => match op_py_any {
-                            None => None,
-                            Some(py_any) => {
-                                let pyobj = py_any.to_object(py);
-                                match from_pyobject(pyobj.as_ref(py)) {
-                                    Ok(val) => val,
-                                    Err(e) => {
-                                        return Err(
-                                            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                                                format!("Error: {:?}", e),
-                                            ),
-                                        )
-                                    }
-                                }
-                            }
-                        },
-                        Err(e) => {
-                            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                                "Error: {:?}",
-                                e
-                            )))
-                        }
-                    };
+                let headers: Option<HashMap<String, String>> = dict
+                    .get_item("headers")?
+                    .map(|value| depythonize(&value).map_err(|e| {
+                        PyErr::new::<PyRuntimeError, _>(format!("Error: {:?}", e))
+                    }))
+                    .transpose()?;
 
-                    let multipart_options: Option<Vec<models::multipart_option::MultipartOption>> =
-                        match dict.get_item("multipart_options") {
-                            Ok(op_py_any) => match op_py_any {
-                                None => None,
-                                Some(py_any) => {
-                                    let pyobj = py_any.to_object(py);
-                                    match from_pyobject(pyobj.as_ref(py)) {
-                                        Ok(val) => val,
-                                        Err(e) => {
-                                            return Err(PyErr::new::<
-                                                pyo3::exceptions::PyRuntimeError,
-                                                _,
-                                            >(
-                                                format!(
-                                                "Error: {:?}",
-                                                e
-                                            )
-                                            ))
-                                        }
-                                    }
-                                }
-                            },
-                            Err(e) => {
-                                return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                                    format!("Error: {:?}", e),
-                                ))
-                            }
-                        };
+                let cookies: Option<String> = dict
+                    .get_item("cookies")?
+                    .map(|value| depythonize(&value).map_err(|e| {
+                        PyErr::new::<PyRuntimeError, _>(format!("Error: {:?}", e))
+                    }))
+                    .transpose()?;
 
-                    setup_options.push(models::setup::SetupApiEndpoint {
-                        name,
-                        url,
-                        method,
-                        json,
-                        form_data,
-                        multipart_options,
-                        headers,
-                        cookies,
-                        jsonpath_extract,
-                    })
-                }
+                let jsonpath_extract: Option<Vec<models::setup::JsonpathExtract>> = dict
+                    .get_item("jsonpath_extract")?
+                    .map(|value| depythonize(&value).map_err(|e| {
+                        PyErr::new::<PyRuntimeError, _>(format!("Error: {:?}", e))
+                    }))
+                    .transpose()?;
+
+                let multipart_options: Option<Vec<models::multipart_option::MultipartOption>> = dict
+                    .get_item("multipart_options")?
+                    .map(|value| depythonize(&value).map_err(|e| {
+                        PyErr::new::<PyRuntimeError, _>(format!("Error: {:?}", e))
+                    }))
+                    .transpose()?;
+
+                setup_options.push(models::setup::SetupApiEndpoint {
+                    name,
+                    url,
+                    method,
+                    json,
+                    form_data,
+                    multipart_options,
+                    headers,
+                    cookies,
+                    jsonpath_extract,
+                });
             }
-            Ok(Option::from(setup_options))
+
+            Ok(Some(setup_options))
         }
-    };
+    }
 }

--- a/src/utils/parse_step_options.rs
+++ b/src/utils/parse_step_options.rs
@@ -2,11 +2,13 @@ use atomic_bomb_engine::models;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-pub fn new(step_option: Option<&PyDict>) -> PyResult<Option<models::step_option::StepOption>> {
+pub fn new(py: Python, step_option: Option<Py<PyDict>>) -> PyResult<Option<models::step_option::StepOption>> {
     match step_option {
         None => Ok(None),
         Some(ops_dict) => {
-            let increase_step: usize = match ops_dict.get_item("increase_step") {
+            let dict_ref = ops_dict.bind(py);
+
+            let increase_step: usize = match dict_ref.get_item("increase_step") {
                 Ok(increase_step_py_any) => match increase_step_py_any {
                     None => {
                         return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
@@ -33,7 +35,7 @@ pub fn new(step_option: Option<&PyDict>) -> PyResult<Option<models::step_option:
                 }
             };
 
-            let increase_interval: u64 = match ops_dict.get_item("increase_interval") {
+            let increase_interval: u64 = match dict_ref.get_item("increase_interval") {
                 Ok(increase_interval_py_any) => match increase_interval_py_any {
                     None => {
                         return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(


### PR DESCRIPTION
…pyo3-asyncio为 pyo3-async-runtimes 并更新相关调用

- 使用 Py::clone 和 bind 方法替代旧的引用传递方式
- 修改函数签名以使用 Py<T> 类型而不是 &T 引用
- 更新 PyDict 和 PyList 的使用方法，使用 unbind() 替代 to_object()
- 引入 PyDictMethods 和 PyListMethods trait 以支持新API
- 更新 serde-pyobject 到 0.6.2 并替换为 pythonize 进行序列化 -优化错误处理逻辑，统一使用 PyErr::new 格式- 简化类型转换过程，移除不必要的中间变量
- 更新构建脚本以支持 Python 3.13 版本- 重构 parse_* 函数以适配新的 PyO3 API 变更- 统一导入语句格式，提高代码可读性- 移除已弃用的 ToPyObject trait 使用- 调整模块初始化函数签名以匹配新版 PyO3 要求