### PR TITLE
build(wheel): 移除不兼容的License元数据并更新许可证格式- 在构建wheel时移除不兼容的License-File元数据

### DIFF
--- a/.github/workflows/build_wheels_linux(musl).yml
+++ b/.github/workflows/build_wheels_linux(musl).yml
@@ -59,6 +59,26 @@ jobs:
       - name: 复制 wheels 到 Runner
         run: docker cp python-alpine-container:/__w/target/wheels ./
 
+      - name: 去除不兼容的 License 元数据
+        run: |
+          python - <<'PY'
+          import pathlib
+          import zipfile
+
+          wheels_dir = pathlib.Path("wheels")
+          for wheel_path in wheels_dir.glob("*.whl"):
+              tmp_path = wheel_path.with_suffix(".tmp")
+              with zipfile.ZipFile(wheel_path) as src, zipfile.ZipFile(tmp_path, "w") as dst:
+                  for info in src.infolist():
+                      data = src.read(info.filename)
+                      if info.filename.endswith(".dist-info/METADATA"):
+                          lines = data.decode("utf-8").splitlines()
+                          lines = [line for line in lines if not line.lower().startswith("license-file:")]
+                          data = ("\n".join(lines) + "\n").encode("utf-8")
+                      dst.writestr(info, data)
+              tmp_path.replace(wheel_path)
+          PY
+
       - name: 安装 Twine
         run: pip install twine
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "atomic_bomb_engine"
 version = "0.42.0"
 description = "使用rust开发的高性能python压测工具"
-license = { file = "LICENSE" }
+license = "MIT"
 readme = "README.md"
 repository = "https://github.com/qyzhg/atomic-bomb-engine-py"
 keywords = ["rust", "python", "binding"]


### PR DESCRIPTION
- 将pyproject.toml中的license字段从文件引用改为直接指定MIT
- 确保wheel构建流程符合标准元数据规范- 避免因License元数据导致的分发问题- 优化wheel构建脚本以提高稳定性 -保持与其他平台构建配置的一致性