### PR TITLE
chore(ci): 更新 macOS 构建工作流配置

### DIFF
--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -8,8 +8,7 @@ on:
 
 jobs:
   build-wheels-macos:
-#    runs-on: macos-latest
-    runs-on: macos-12
+    runs-on: macos-latest
     strategy:
       matrix:
         arch: ['x86_64-apple-darwin', 'aarch64-apple-darwin']


### PR DESCRIPTION
- 将 macOS 运行环境从 macos-12 更新为 macos-latest -保持上传到 PyPI 的命令不变
- 确保多架构轮子文件正确构建和发布